### PR TITLE
Enable CI on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os: [
           windows-latest,
-          # macos-latest, # cppfront is currently broken on AppleClang
+          macos-latest,
           ubuntu-latest,
         ]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
I definitely expect this to fail since AppleClang's C++20 support is lacking. Leaving this open just so I'm ready if support ever arrives.