### PR TITLE
Fix regression tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,16 +11,16 @@ project(
 include(CMakeDependentOption)
 
 cmake_dependent_option(
-    CPPFRONT_INSTALL_RULES "Include install rules for cppfront" "${PROJECT_IS_TOP_LEVEL}"
-    "NOT CMAKE_SKIP_INSTALL_RULES" OFF
-)
-mark_as_advanced(CPPFRONT_INSTALL_RULES)
-
-cmake_dependent_option(
     CPPFRONT_NO_SYSTEM "Do not mark cpp2 runtime headers as SYSTEM" OFF
     "NOT PROJECT_IS_TOP_LEVEL" ON
 )
 mark_as_advanced(CPPFRONT_NO_SYSTEM)
+
+cmake_dependent_option(
+    CPPFRONT_INSTALL_RULES "Include install rules for cppfront" "${PROJECT_IS_TOP_LEVEL}"
+    "NOT CMAKE_SKIP_INSTALL_RULES" OFF
+)
+mark_as_advanced(CPPFRONT_INSTALL_RULES)
 
 ##
 # Target definition for cppfront executable
@@ -33,14 +33,17 @@ set_target_properties(
     OUTPUT_NAME cppfront
     EXPORT_NAME cppfront
 )
-
 target_compile_features(cppfront_cppfront PRIVATE cxx_std_20)
 target_sources(
     cppfront_cppfront
     PRIVATE
     FILE_SET HEADERS
     BASE_DIRS cppfront/source
-    FILES cppfront/source/common.h cppfront/source/lex.h cppfront/source/load.h cppfront/source/parse.h cppfront/source/sema.h
+    FILES cppfront/source/common.h
+          cppfront/source/lex.h
+          cppfront/source/load.h
+          cppfront/source/parse.h
+          cppfront/source/sema.h
 )
 
 ##

--- a/cmake/cppfront-config.cmake.in
+++ b/cmake/cppfront-config.cmake.in
@@ -4,5 +4,8 @@ cmake_minimum_required(VERSION 3.23)
 include("${CMAKE_CURRENT_LIST_DIR}/cppfront-targets.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/CppfrontHelpers.cmake")
 
-set_and_check(CPPFRONT_EXECUTABLE "@PACKAGE_CMAKE_INSTALL_BINDIR@/cppfront@CMAKE_EXECUTABLE_SUFFIX@")
+set_and_check(
+    CPPFRONT_EXECUTABLE
+    "@PACKAGE_CMAKE_INSTALL_BINDIR@/cppfront@CMAKE_EXECUTABLE_SUFFIX@"
+)
 check_required_components(cppfront)

--- a/regression-tests/CMakeLists.txt
+++ b/regression-tests/CMakeLists.txt
@@ -29,6 +29,7 @@ function(cppfront_command_tests)
     string(REPLACE "." "\\." expected_output "${expected_output}")
     string(REPLACE "+" "\\+" expected_output "${expected_output}")
     string(REPLACE "*" "\\*" expected_output "${expected_output}")
+    string(REPLACE "?" "\\?" expected_output "${expected_output}")
 
     set_tests_properties(
         "codegen/${test_name}"


### PR DESCRIPTION
Regression tests are failing because of the presence of unescaped `?` characters in the expected output.

Also a little minor code reformatting (to match forthcoming blog post)