### PR TITLE
include the missing cpp2regex.h in cpp2util target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Clang 18 is broken for some reason
-          # - CC: clang-18
-          #   CXX: clang++-18
-          #   CXXFLAGS: -stdlib=libc++
+          # Clang 18.1.3 or later works
+          - CC: clang-18
+            CXX: clang++-18
+            CXXFLAGS: -stdlib=libc++
           - CC: gcc-14
             CXX: g++-14
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ target_sources(
     INTERFACE
     FILE_SET HEADERS
     BASE_DIRS cppfront/include
-    FILES cppfront/include/cpp2util.h
+    FILES cppfront/include/cpp2util.h cppfront/include/cpp2regex.h
 )
 
 if (NOT CPPFRONT_NO_SYSTEM)

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ configuration:
 
 * `cppfront::cppfront` -- this is the executable for the cppfront compiler
 * `cppfront::cpp2util` -- this is an `INTERFACE` library providing the path to
-  the `cpp2util.h` runtime header.
+  the `cpp2util.h` and `cpp2regex.h` runtime headers.
 
 ### Options
 


### PR DESCRIPTION
Currently, the required `cpp2regex.h` is not getting installed and the example cannot be built.

Changes:

* include `cpp2regex.h` for the target `cpp2util`.
* update cppfront submodule to [v0.7.2](https://github.com/hsutter/cppfront/releases/tag/v0.7.2)

Tested on Ubuntu 24.04 with `cmake` 3.30.1.