### PR TITLE
Apply /bigobj to fix debug builds on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,23 @@ target_sources(
           cppfront/source/sema.h
 )
 
+# clang-cl: Clang on windows
+if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang") AND (CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC"))
+    set(CLANG_CL 1)
+endif()
+
+# Fix for debug builds on windows
+# "fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj"
+target_compile_options(
+    cppfront_cppfront PRIVATE
+    # Visual C++ for windows
+    $<$<BOOL:${MSVC}>:/bigobj>
+    # GCC for windows
+    $<$<BOOL:${MINGW}>:-Wa,-mbig-obj>
+    # Clang for windows
+    $<$<BOOL:${CLANG_CL}>:-bigobj>
+)
+
 ##
 # Target definition for cpp2util runtime library
 


### PR DESCRIPTION
CMAKE_BUILD_TYPE: Debug
CMake: 3.30.5

### Windows + MSVC 17.0 + Debug error:
```
cppfront/source/cppfront.cpp: "fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj"
```

### Windows + MinGW 11.0 w64 + Debug:
Appeared to hang, 10+ min and hadn't finished compiling.

### Fix:
Adding the bigobj flag fixed the issues with both msvc and mingw.
Added the fix for clang-cl as well, but haven't tested it.

### Sources:

Sources for MSVC error/flag:
[Fatal Error C1128](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/fatal-error-c1128?view=msvc-170)
[/bigobj (Increase Number of Sections in .Obj file)](https://learn.microsoft.com/en-us/cpp/build/reference/bigobj-increase-number-of-sections-in-dot-obj-file?view=msvc-170)

Sources for MinGW flag:
[Mingw-w64: How to fix “File too big/too many sections”](https://digitalkarabela.com/mingw-w64-how-to-fix-file-too-big-too-many-sections/)
[GCC equivalent of MS's /bigobj](https://stackoverflow.com/a/31907912/5188428)

Sources for clang-cl flag:
[How to add /bigobj switch to clang with ms code gen?](https://stackoverflow.com/a/37561988/5188428)

Sources for determining compiler used:
[MSVC](https://cmake.org/cmake/help/latest/variable/MSVC.html)
[MinGW](https://cmake.org/cmake/help/latest/variable/MINGW.html)
[clang-cl](https://stackoverflow.com/a/10055571/5188428)